### PR TITLE
mellanox/diverse: update srpm paths in drivers

### DIFF
--- a/mellanox/libibverbs/centos/srpm_path
+++ b/mellanox/libibverbs/centos/srpm_path
@@ -1,1 +1,1 @@
-repo:addons/wr-avs/layers/avs/downloads/libibverbs-41mlnx1-OFED.4.2.1.0.6.42120.src.rpm
+repo:addons/wr-cgcs/layers/cgcs/downloads/libibverbs-41mlnx1-OFED.4.2.1.0.6.42120.src.rpm

--- a/mellanox/libmlx4/centos/srpm_path
+++ b/mellanox/libmlx4/centos/srpm_path
@@ -1,1 +1,1 @@
-repo:addons/wr-avs/layers/avs/downloads/libmlx4-41mlnx1-OFED.4.1.0.1.0.42120.src.rpm
+repo:addons/wr-cgcs/layers/cgcs/downloads/libmlx4-41mlnx1-OFED.4.1.0.1.0.42120.src.rpm

--- a/mellanox/libmlx5/centos/srpm_path
+++ b/mellanox/libmlx5/centos/srpm_path
@@ -1,1 +1,1 @@
-repo:addons/wr-avs/layers/avs/downloads/libmlx5-41mlnx1-OFED.4.2.1.2.0.42120.src.rpm
+repo:addons/wr-cgcs/layers/cgcs/downloads/libmlx5-41mlnx1-OFED.4.2.1.2.0.42120.src.rpm

--- a/mellanox/mlnx-ofa_kernel/centos/srpm_path
+++ b/mellanox/mlnx-ofa_kernel/centos/srpm_path
@@ -1,1 +1,1 @@
-repo:addons/wr-avs/layers/avs/downloads/mlnx-ofa_kernel-4.3-OFED.4.3.1.0.1.1.g8509e41.src.rpm
+repo:addons/wr-cgcs/layers/cgcs/downloads/mlnx-ofa_kernel-4.3-OFED.4.3.1.0.1.1.g8509e41.src.rpm

--- a/mellanox/rdma-core/centos/srpm_path
+++ b/mellanox/rdma-core/centos/srpm_path
@@ -1,1 +1,1 @@
-repo:addons/wr-avs/layers/avs/downloads/rdma-core-43mlnx1-1.43101.src.rpm
+repo:addons/wr-cgcs/layers/cgcs/downloads/rdma-core-43mlnx1-1.43101.src.rpm


### PR DESCRIPTION
The srpm_path in these drivers points to a downloads directory. That
downloads directory has moved. This updates the path to point to the
current location.

Note: This will need to be updated again when the files in downloads
are moved and populated by the mirror scripts and reside in
/import/mirrors.

Signed-off-by: brian avery <brian.avery@intel.com>